### PR TITLE
Add perform[] functionality from OUTRAGE V2

### DIFF
--- a/classes/outragebot/connection/socket.php
+++ b/classes/outragebot/connection/socket.php
@@ -199,6 +199,9 @@ class Socket
 	{
 		foreach($this->parent->network->channels as $channel)
 			$this->write("JOIN ".$channel);
+
+		foreach($this->parent->network->perform as $command)
+			$this->write($command);
 		
 		return $this->prepared = true;
 	}

--- a/configuration/template.json-dist
+++ b/configuration/template.json-dist
@@ -10,6 +10,7 @@ network:
 	scripts: [ "evaluation", "commands" ]
 	
 	delimiter: "@"
+	perform: [ ]
 }
 
 bots:


### PR DESCRIPTION
Implements an array of RAW commands that can be sent once the bot has fully initialised and connected

Useful for supplementary IRC commands.
