### PR TITLE
Add support for nick registration detection

### DIFF
--- a/classes/outragebot/module/modules/whois.php
+++ b/classes/outragebot/module/modules/whois.php
@@ -38,6 +38,7 @@ class Whois extends Module\Template
 			"retrieve" => array
 			(
 				"301" => [ $this, "parseInputAwayMessage" ],
+				"307" => [ $this, "parseInputRegistered" ],
 				"310" => [ $this, "parseInputHelperMessage" ],
 				"311" => [ $this, "parseInputUser" ],
 				"312" => [ $this, "parseInputServer" ],
@@ -75,6 +76,15 @@ class Whois extends Module\Template
 	public function parseInputAwayMessage(Connection\Packet $packet)
 	{
 		$this->response->away = $packet->payload;
+	}
+
+
+	/**
+	 *	WHOIS Response: Nick registration status
+	 */
+	public function parseInputRegistered(Connection\Packet $packet)
+	{
+		$this->response->registered = true;
 	}
 	
 	
@@ -205,6 +215,7 @@ class Whois extends Module\Template
 			"ipAddress" => null,
 			"userModes" => null,
 			"serverModes" => null,
+			"registered" => false
 		);
 		
 		$response = new Core\ObjectContainer();


### PR DESCRIPTION
Allows detection of when a nickname is registered with IRC services.

This is identified when numeric 307 is sent.
