### PR TITLE
Patch perform[] properly

### DIFF
--- a/classes/outragebot/connection/socket.php
+++ b/classes/outragebot/connection/socket.php
@@ -226,11 +226,20 @@ class Socket
 				$this->write($command);
 		}
 
-		# Join channels specified in configuration file
-		if(!empty($this->parent->network->channels))
+		# Join channels specified in configuration file on a 5 second delay
+		if($closure = Module\Stack::getInstance()->getClosure("addTimer"))
 		{
-			foreach($this->parent->network->channels as $channel)
-				$this->write("JOIN ".$channel);
+			$context = new Element\Context();
+			$context->callee = $this;
+
+			$closure($context, function()
+			{
+				if(!empty($this->parent->network->channels))
+				{
+					foreach($this->parent->network->channels as $channel)
+						$this->write("JOIN ".$channel);
+				}
+			}, 5);
 		}
 		
 		return $this->prepared = true;

--- a/classes/outragebot/connection/socket.php
+++ b/classes/outragebot/connection/socket.php
@@ -227,19 +227,19 @@ class Socket
 		}
 
 		# Join channels specified in configuration file on a 5 second delay
-		if($closure = Module\Stack::getInstance()->getClosure("addTimer"))
+		if(!empty($this->parent->network->channels))
 		{
-			$context = new Element\Context();
-			$context->callee = $this;
-
-			$closure($context, function()
+			if($closure = Module\Stack::getInstance()->getClosure("addTimer"))
 			{
-				if(!empty($this->parent->network->channels))
+				$context = new Element\Context();
+				$context->callee = $this;
+
+				$closure($context, function ()
 				{
 					foreach($this->parent->network->channels as $channel)
-						$this->write("JOIN ".$channel);
-				}
-			}, 5);
+						$this->write("JOIN " . $channel);
+				}, 5);
+			}
 		}
 		
 		return $this->prepared = true;

--- a/classes/outragebot/connection/socket.php
+++ b/classes/outragebot/connection/socket.php
@@ -219,16 +219,18 @@ class Socket
 	 */
 	public function ready()
 	{
-		if(!empty($this->parent->network->channels))
-		{
-			foreach($this->parent->network->channels as $channel)
-				$this->write("JOIN ".$channel);
-		}
-		
+		# Run perform[] commands from configuration file
 		if(!empty($this->parent->network->perform))
 		{
 			foreach($this->parent->network->perform as $command)
 				$this->write($command);
+		}
+
+		# Join channels specified in configuration file
+		if(!empty($this->parent->network->channels))
+		{
+			foreach($this->parent->network->channels as $channel)
+				$this->write("JOIN ".$channel);
 		}
 		
 		return $this->prepared = true;


### PR DESCRIPTION
This PR does two things:

1) perform[] commands now run before joining channels, which is a better order for things like NickServ identification

2) Channels are joined on a timer to allow the IRC server to "catch up" - also removes the need for sleep() and won't harm multiple bot instances by locking them up
